### PR TITLE
Preserve original filename in converted download

### DIFF
--- a/app.py
+++ b/app.py
@@ -36,6 +36,15 @@ except OSError as e:
 _SESSION_RE = re.compile(r'^[0-9a-f]{32}$')
 _COLOR_RE   = re.compile(r'^#[0-9A-Fa-f]{6}([0-9A-Fa-f]{2})?$')
 
+# Maps session_id -> original filename stem (for download naming)
+_session_names: dict[str, str] = {}
+
+
+def _sanitize_download_name(name: str) -> str:
+    """Remove characters invalid in filenames while preserving non-ASCII."""
+    cleaned = re.sub(r'[\\/:*?"<>|\x00-\x1f]', '', name).strip()
+    return cleaned or 'converted'
+
 # ---------------------------------------------------------------------------
 # Filament profiles (loaded once at startup)
 # ---------------------------------------------------------------------------
@@ -75,6 +84,9 @@ def cleanup_old_files() -> None:
 
 def _schedule_cleanup(interval: int = 3600) -> None:
     cleanup_old_files()
+    for sid in list(_session_names):
+        if _safe_path(f'{sid}_input.3mf') is None or not os.path.exists(_safe_path(f'{sid}_input.3mf')):
+            _session_names.pop(sid, None)
     Timer(interval, _schedule_cleanup, [interval]).start()
 
 
@@ -161,6 +173,8 @@ def analyze():
         return jsonify({'error': 'Only .3mf files are accepted'}), 400
 
     session_id     = uuid.uuid4().hex          # 32 hex chars, full 128-bit entropy
+    raw_name = file.filename.rsplit('.', 1)[0] if '.' in file.filename else file.filename
+    _session_names[session_id] = _sanitize_download_name(raw_name)
     input_filename = f'{session_id}_input.3mf'
     filepath       = _safe_path(input_filename)
     if filepath is None:
@@ -375,7 +389,9 @@ def download_file(filename: str):
     filepath = _safe_path(filename)
     if filepath is None or not os.path.exists(filepath):
         return jsonify({'error': 'File not found'}), 404
-    return send_file(filepath, as_attachment=True, download_name='Snapmaker_U1_Ready.3mf')
+    session_id    = filename[:32]
+    original_name = _session_names.get(session_id, 'converted')
+    return send_file(filepath, as_attachment=True, download_name=f'{original_name}-U1.3mf')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

- The download was always named \`Snapmaker_U1_Ready.3mf\` regardless of the uploaded file's name
- Added \`_session_names\` dict to store each session's original filename stem at upload time
- Added \`_sanitize_download_name()\` to strip only characters invalid in filenames, preserving non-ASCII characters (unlike \`werkzeug.secure_filename\` which strips them)
- \`/download\` now resolves the original name and serves the file as \`{original_name}-U1.3mf\`
- Stale \`_session_names\` entries are pruned during the background cleanup

## Test plan

- [x] Upload a file named \`my_model.3mf\` → download should be named \`my_model-U1.3mf\` — _verified: API returned \`download_name: "my_model-U1.3mf"\`_
- [x] Upload a file with non-ASCII characters (e.g. \`diseño.3mf\`) → name should be preserved — _verified: API returned \`download_name: "diseño-U1.3mf"\`_
- [x] Upload a file with special characters (e.g. \`model:v2.3mf\`) → invalid chars stripped, rest preserved — _verified: colon stripped, API returned \`download_name: "modelv2-U1.3mf"\`_

🤖 Generated with [Claude Code](https://claude.com/claude-code)